### PR TITLE
Change secret name to match what is created in the the blog post

### DIFF
--- a/containerd/cert-ds.yaml
+++ b/containerd/cert-ds.yaml
@@ -54,7 +54,7 @@ spec:
         name: etc
       - name: registry-cert
         secret:
-          secretName: artifactory-pem
+          secretName: registry-pem
           defaultMode: 420
       - name: containerd-config
         configMap:

--- a/docker/cert-ds.yaml
+++ b/docker/cert-ds.yaml
@@ -51,7 +51,7 @@ spec:
         name: etc
       - name: registry-cert
         secret:
-          secretName: artifactory-pem
+          secretName: registry-pem
           defaultMode: 420
       - name: entrypoint
         configMap:


### PR DESCRIPTION
Currently if you follow the blog post the daemonset does not come up because the secret referenced does not exist. This makes the referenced secret match the blog post.